### PR TITLE
Edp/fix test persistant metadata storage

### DIFF
--- a/build/setup_burrito_store.js
+++ b/build/setup_burrito_store.js
@@ -5,27 +5,38 @@ const fse = require('fs-extra');
 const xmldom = require('xmldom');
 
 const DBLImport = require('../code/dbl_metadata_import.js').DBLImport;
-const FSBurritoStore = require('../fs_burrito_store.js').FSBurritoStore;
+const { createFSBurritoStore } = require('../fs_burrito_store.js');
 
 const testDataDir = path.join(__dirname, '..', 'test', 'test_data');
 const dblMetadataDir = path.join(testDataDir, 'dbl_metadata');
 const oabDataDir = path.join(dblMetadataDir, 'oab');
 const bundleDir = path.join(testDataDir, 'dbl_bundles', 'dbl_unit_test_text');
 
-const burritoStore = new FSBurritoStore(
-  {
-    storeClass: 'FSBurritoStore',
-    validation: 'burrito',
-  },
-  process.argv[2],
-);
-fse.readdirSync(oabDataDir).forEach((file) => {
-  console.log(file);
-  const entry = new xmldom.DOMParser().parseFromString(
-    fse.readFileSync(path.join(oabDataDir, file), 'utf8'),
-    'text/xml',
+async function setupBurritoStore() {
+  const burritoStore = await createFSBurritoStore(
+    {
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    process.argv[2],
   );
-  const converted = new DBLImport(entry);
-  burritoStore.importFromObject(converted.sbMetadata);
-});
-burritoStore.importFromDir(bundleDir);
+  fse.readdirSync(oabDataDir).forEach((file) => {
+    console.log(file);
+    const entry = new xmldom.DOMParser().parseFromString(
+      fse.readFileSync(path.join(oabDataDir, file), 'utf8'),
+      'text/xml',
+    );
+    const converted = new DBLImport(entry);
+    burritoStore.importFromObject(converted.sbMetadata);
+  });
+  burritoStore.importFromDir(bundleDir);
+  return burritoStore;
+}
+
+(async () => {
+  try {
+    await setupBurritoStore();
+  } catch (e) {
+    // Deal with the fact the chain failed
+  }
+})();

--- a/code/fs_metadata_store.js
+++ b/code/fs_metadata_store.js
@@ -16,6 +16,10 @@ class FSMetadataStore extends MetadataStore {
     this._urls = {};
     this._idServers = {};
     this.metadataDir = `${sDir}/metadata`;
+    this.afterCreate();
+  }
+
+  afterCreate() {
     if (fse.existsSync(this.metadataDir)) {
       this.loadEntries();
     } else {
@@ -25,27 +29,27 @@ class FSMetadataStore extends MetadataStore {
 
   /**
      */
-  async loadEntries() {
+  loadEntries() {
     const self = this;
     try {
-      const urls = await fse.readdir(self.metadataDir);
+      const urls = fse.readdirSync(self.metadataDir);
       urls.forEach(async (url) => {
         const decodedUrl = decodeURIComponent(url);
         self._urls[decodedUrl] = {};
         const urlDir = `${self.metadataDir}/${url}`;
-        const entries = await fse.readdir(urlDir);
+        const entries = fse.readdirSync(urlDir);
         entries.forEach(async (entry) => {
           const decodedEntry = decodeURIComponent(entry);
           self._urls[decodedUrl][decodedEntry] = {};
           const entryDir = `${urlDir}/${entry}`;
           try {
-            const revisions = fse.readdir(entryDir);
+            const revisions = fse.readdirSync(entryDir);
             revisions.forEach(async (revision) => {
               const decodedRevision = decodeURIComponent(revision);
               self._urls[decodedUrl][decodedEntry][decodedRevision] = {};
               const revisionDir = `${entryDir}/${revision}`;
               try {
-                const variants = await fse.readdir(revisionDir);
+                const variants = fse.readdirSync(revisionDir);
                 variants.forEach((variant) => {
                   const decodedVariant = decodeURIComponent(variant);
                   const variantDir = `${revisionDir}/${variant}/metadata.json`;

--- a/fs_burrito_store.js
+++ b/fs_burrito_store.js
@@ -16,11 +16,10 @@ class FSBurritoStore extends BurritoStore {
        Metadata is loaded into working memory but cached using the filesystem.
        Ingredients are stored using the filesystem.
     */
-  constructor(configJson, sDir) {
+  async initializeIngredientsAndMetadataStores(sDir) {
     if (!sDir) {
       throw new BurritoError('StorageDirNotDefined');
     }
-    super(configJson);
     if (!fse.existsSync(sDir)) {
       fse.mkdirSync(sDir, { recursive: false });
     }
@@ -98,4 +97,10 @@ class FSBurritoStore extends BurritoStore {
   }
 }
 
-export { FSBurritoStore };
+async function createFSBurritoStore(configJson, sDir) {
+  const fsBurritoStore = new FSBurritoStore(configJson);
+  await fsBurritoStore.initializeIngredientsAndMetadataStores(sDir);
+  return fsBurritoStore;
+}
+
+export { FSBurritoStore, createFSBurritoStore };

--- a/test/package.json
+++ b/test/package.json
@@ -36,7 +36,7 @@
           "plugin:mocha/recommended"
         ],
         "rules" : {
-          "mocha/no-mocha-arrows": "warn",
+          "mocha/no-mocha-arrows": "off",
           "no-undef": "off",
           "func-names": "off"
         }

--- a/test/test_bundle_import.js
+++ b/test/test_bundle_import.js
@@ -1,48 +1,49 @@
-
 require = require('esm')(module /* , options */);
 const assert = require('chai').assert;
 const path = require('path');
 const fse = require('fs-extra');
-const xmldom = require('xmldom');
 
-const FSBurritoStore = require('../fs_burrito_store.js').FSBurritoStore;
+const { createFSBurritoStore } = require('../fs_burrito_store.js');
 const DBLImport = require('../code/dbl_metadata_import.js').DBLImport;
 const BurritoValidator = require('../code/burrito_validator.js').BurritoValidator;
 
-describe('Bundle Import', function() {
-  before(function () {
-    this.storagePath = path.join(__dirname, 'test_temp_storage');
-    this.testDataDir = path.join(__dirname, 'test_data');
-    this.bundleDir = path.join(this.testDataDir, 'dbl_bundles', 'dbl_unit_test_text');
-    this.domParser = new xmldom.DOMParser();
+describe('Bundle Import', () => {
+  let storagePath;
+  let testDataDir;
+  let bundleDir;
+
+  before(async () => {
+    storagePath = path.join(__dirname, 'test_temp_storage');
+    testDataDir = path.join(__dirname, 'test_data');
+    bundleDir = path.join(testDataDir, 'dbl_bundles', 'dbl_unit_test_text');
   });
 
-  afterEach(function () {
-    if (fse.existsSync(this.storagePath)) {
-      fse.removeSync(this.storagePath);
+  afterEach(async () => {
+    if (fse.existsSync(storagePath)) {
+      fse.removeSync(storagePath);
     }
   });
 
-  it('Import DBL Unit Test Text Entry using Stored SB Metadata', function () {
-    const b = new FSBurritoStore(
+  it('Import DBL Unit Test Text Entry using Stored SB Metadata', async () => {
+    const b = await createFSBurritoStore(
       {
         storeClass: 'FSBurritoStore',
         validation: 'burrito',
       },
-      this.storagePath,
+      storagePath,
     );
-    const [sysUrl, entryId, entryRevision, variant] = b.importFromDir(this.bundleDir);
+    const [sysUrl, entryId, entryRevision, variant] = b.importFromDir(bundleDir);
     assert.equal(Object.keys(b.ingredients(sysUrl, entryId, entryRevision, variant)).length, 8);
   });
 
-  it('Import DBL Unit Test Text Entry using Stored DBL Metadata', function () {
-    const b = new FSBurritoStore(
+  it('Import DBL Unit Test Text Entry using Stored DBL Metadata', async () => {
+    const b = await createFSBurritoStore(
       {
         storeClass: 'FSBurritoStore',
         validation: 'burrito',
       },
-      this.storagePath,
+      storagePath,
     );
-    const [sysUrl, entryId, entryRevision, variant] = b.importFromDblDir(this.bundleDir);
+    const [sysUrl, entryId, entryRevision, variant] = b.importFromDblDir(bundleDir);
   });
 });

--- a/test/test_fs_burrito_store.js
+++ b/test/test_fs_burrito_store.js
@@ -614,7 +614,7 @@ describe('FS Burrito Class', () => {
   });
 
   // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('Persistant metadata storage', function () {
+  it('Persistant metadata storage', function () {
     const b = new FSBurritoStore(
       {
         storeClass: 'FSBurritoStore',

--- a/test/test_fs_burrito_store.js
+++ b/test/test_fs_burrito_store.js
@@ -622,7 +622,6 @@ describe('FS Burrito Class', () => {
       },
       this.storagePath,
     );
-    // await b.afterCreate();
     b.importFromObject(this.metadata.validTextTranslation);
     const b2 = new FSBurritoStore(
       {
@@ -631,7 +630,6 @@ describe('FS Burrito Class', () => {
       },
       this.storagePath,
     );
-    // await b2.afterCreate();
     assert.equal(b2.entryRevisionVariants('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91').length, 1);
   });
 });

--- a/test/test_fs_burrito_store.js
+++ b/test/test_fs_burrito_store.js
@@ -622,6 +622,7 @@ describe('FS Burrito Class', () => {
       },
       this.storagePath,
     );
+    // await b.afterCreate();
     b.importFromObject(this.metadata.validTextTranslation);
     const b2 = new FSBurritoStore(
       {
@@ -630,6 +631,7 @@ describe('FS Burrito Class', () => {
       },
       this.storagePath,
     );
+    // await b2.afterCreate();
     assert.equal(b2.entryRevisionVariants('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91').length, 1);
   });
 });

--- a/test/test_schema.js
+++ b/test/test_schema.js
@@ -1,36 +1,42 @@
-
 require = require('esm')(module /* , options */);
 const assert = require('chai').assert;
 const path = require('path');
 const fse = require('fs-extra');
 
-const FSBurritoStore = require('../fs_burrito_store.js').FSBurritoStore;
+const { createFSBurritoStore } = require('../fs_burrito_store.js');
 
-describe('Schema', function() {
-  before(function () {
-    this.testDataDir = path.join(__dirname, 'test_data');
-    this.storagePath = path.join(__dirname, 'test_temp_storage');
-    const metadataDir = path.join(this.testDataDir, 'metadata');
-    this.validTextTranslation = JSON.parse(
+describe('Schema', () => {
+  let testDataDir;
+  let storagePath;
+  let metadataDir;
+  let validTextTranslation;
+
+  // eslint-disable-next-line mocha/no-hooks-for-single-case
+  before(async () => {
+    testDataDir = path.join(__dirname, 'test_data');
+    storagePath = path.join(__dirname, 'test_temp_storage');
+    metadataDir = path.join(testDataDir, 'metadata');
+    validTextTranslation = JSON.parse(
       fse.readFileSync(path.join(metadataDir, 'textTranslation.json'), 'utf8'),
     );
   });
 
-  afterEach(function () {
-    if (fse.existsSync(this.storagePath)) {
-      fse.removeSync(this.storagePath);
+  // eslint-disable-next-line mocha/no-hooks-for-single-case
+  afterEach(async () => {
+    if (fse.existsSync(storagePath)) {
+      fse.removeSync(storagePath);
     }
   });
 
-  it('Accept test textTranslation document', function () {
-    const b = new FSBurritoStore(
+  it('Accept test textTranslation document', async () => {
+    const b = await createFSBurritoStore(
       {
         storeClass: 'FSBurritoStore',
       },
-      this.storagePath,
+      storagePath,
     );
     try {
-      b.importFromObject(this.validTextTranslation);
+      b.importFromObject(validTextTranslation);
     } catch (err) {
       console.log(err.message);
       console.log(err.arg);


### PR DESCRIPTION
I've begun adding general support for async - await, so that async await can start to be used for filesystem operations.

This involves some restructuring of mocha tests. Doesn't seem to be too bad to me, but I had to completely disable the rule to not use arrow functions in mocha tests. `mocha/no-mocha-arrows` and get rid of references to `this`.

One possible implication is that references to `sDir` should be moved out of the contructor and into the factory method for each class, since usage of `sDir` is likely to block for too long.