### PR TITLE
burrito store export as zip support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,9 @@
     "object-curly-newline": [
       "error",
       {
-        "ObjectExpression": "always",
+        "ObjectExpression": {
+          "multiline": true
+        },
         "ObjectPattern": {
           "multiline": true
         },

--- a/code/burrito_store.js
+++ b/code/burrito_store.js
@@ -1,5 +1,5 @@
 import * as xmldom from 'xmldom';
-import { default as AdmZip } from 'adm-zip';
+import AdmZip from 'adm-zip';
 
 import { BurritoError } from './burrito_error.js';
 import { ConfigReader } from './config_reader.js';
@@ -33,8 +33,7 @@ class BurritoStore {
 
   /* Utilities */
 
-  /**
-     */
+  /** */
   idServerName(idServerId) {
     throw new BurritoError('MethodNotYetImplemented');
   }
@@ -191,7 +190,18 @@ class BurritoStore {
   }
 
   exportToZipfile(idServerId, entryId, revisionId, variantId, toPath) {
-    throw new BurritoError('MethodNotYetImplemented');
+    const zip = new AdmZip();
+    zip.addFile(
+      'metadata.json',
+      JSON.stringify(
+        this.metadataContent(idServerId, entryId, revisionId, variantId), null, 2,
+      ),
+    );
+    zip.writeZip(toPath, (error) => {
+      if (error) {
+        throw new BurritoError(`Error writing zip to '${toPath}', message '${error.message}'`);
+      }
+    });
   }
 
   /* toTemplate */

--- a/test/test_fs_burrito_store.js
+++ b/test/test_fs_burrito_store.js
@@ -1,4 +1,6 @@
 require = require('esm')(module /* , options */);
+const { it, describe, before, afterEach } = require('mocha');
+const AdmZip = require('adm-zip');
 const deepcopy = require('deepcopy');
 const fse = require('fs-extra');
 const path = require('path');
@@ -39,8 +41,8 @@ describe('FS Burrito Class', () => {
     this.mp3Path = path.join(this.testDataDir, 'ingredients', 'GEN_001.mp3');
     this.jhn3Mp3Paths = [
       path.join(this.testDataDir, 'ingredients', 'JHN_003_gnt.mp3'),
-      path.join(this.testDataDir, 'ingredients', 'JHN_003_kjv.mp3')
-      ];
+      path.join(this.testDataDir, 'ingredients', 'JHN_003_kjv.mp3'),
+    ];
   });
 
   afterEach(function () {
@@ -58,14 +60,12 @@ describe('FS Burrito Class', () => {
   };
 
   it('Constructs successfully', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     assert.exists(b);
     assert.equal(b._config.storeClass, 'FSBurritoStore');
     assert.equal(b._config.validation, 'burrito');
@@ -76,12 +76,8 @@ describe('FS Burrito Class', () => {
 
   it('Requires storeClass to match class', function () {
     try {
-      const b = new FSBurritoStore(
-        {
-          storeClass: 'banana',
-        },
-        this.storagePath,
-      );
+      const b = new FSBurritoStore({ storeClass: 'banana' },
+        this.storagePath);
       throw Error('Too Far');
     } catch (err) {
       assert.equal(err.message, 'ConfigJsonForWrongClass');
@@ -90,13 +86,11 @@ describe('FS Burrito Class', () => {
 
   it('Throws error on invalid config', function () {
     try {
-      const b = new FSBurritoStore(
-        {
-          storeClass: 'FSBurrito',
-          foo: 'baa',
-        },
-        this.storagePath,
-      );
+      const b = new FSBurritoStore({
+        storeClass: 'FSBurrito',
+        foo: 'baa',
+      },
+      this.storagePath);
       throw Error('Too Far');
     } catch (err) {
       assert.equal(err.message, 'ConfigFileInvalid');
@@ -108,51 +102,43 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements importFromObject', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
   });
 
   it('Imports derived variant', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        acceptedDerivedVariants: ['derived_foo'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      acceptedDerivedVariants: ['derived_foo'],
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validDerivedTextTranslation);
   });
 
   it('Allow import of identical metadata twice', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
     b.importFromObject(this.metadata.validTextTranslation);
   });
 
   it('Do not allow import of different metadata for existing variant', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.validTextTranslation);
       const modifiedMetadata = deepcopy(this.metadata.validTextTranslation);
@@ -165,14 +151,12 @@ describe('FS Burrito Class', () => {
   });
 
   it('Throws exception from importFromObject on multiple revisions', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.scriptureTextDupRevision);
       assert.exists(b);
@@ -183,14 +167,12 @@ describe('FS Burrito Class', () => {
   });
 
   it('Throws exception from importFromObject on no revision', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-        subclassSettings: { foo: 'baa' },
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+      subclassSettings: { foo: 'baa' },
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.scriptureTextNoRevision);
       assert.exists(b);
@@ -201,13 +183,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Raises exception on adding variant with unsupported version', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedVersion: '0.2',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedVersion: '0.2',
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.obsoleteStub);
       throw new Error('Too Far', {});
@@ -218,12 +198,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Raises exception on adding variant with x-flavor when not configured to accept', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     try {
       b.importFromObject(this.metadata.xStub);
       throw new Error('Too Far', {});
@@ -235,13 +211,11 @@ describe('FS Burrito Class', () => {
 
   it('Accepts variant with x-flavor when configured to accept', function () {
     /* Schema invalid because metadata is stub */
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        allowXFlavors: true,
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      allowXFlavors: true,
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.xStub);
       throw new Error('Too Far', {});
@@ -251,13 +225,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Raises exception on adding variant with no accepted id', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.badServerStub);
       throw new Error('Too Far', {});
@@ -268,25 +240,21 @@ describe('FS Burrito Class', () => {
   });
 
   it('Accepts variant with explicit ID Server config', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
     assert.exists(b);
   });
 
   it('Raises exception on adding unknown variant', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.bananaVariantStub);
       throw new Error('Too Far', {});
@@ -297,14 +265,12 @@ describe('FS Burrito Class', () => {
   });
 
   it('Accepts derived variant with * config', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
-        acceptedDerivedVariants: ['*'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
+      acceptedDerivedVariants: ['*'],
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.bananaVariantStub);
       throw new Error('Too Far', {});
@@ -314,14 +280,12 @@ describe('FS Burrito Class', () => {
   });
 
   it('Accepts derived variant with explicit config', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
-        acceptedDerivedVariants: ['derived_banana'],
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      acceptedIdServers: ['https://thedigitalbiblelibrary.org'],
+      acceptedDerivedVariants: ['derived_banana'],
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.bananaVariantStub);
       throw new Error('Too Far', {});
@@ -331,12 +295,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements idServers()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.equal(b.idServers().length, 0);
     b.importFromObject(this.metadata.validTextTranslation);
     assert.equal(b.idServers().length, 1);
@@ -344,12 +304,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements idServersDetails()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.equal(Object.keys(b.idServersDetails()).length, 0);
     b.importFromObject(this.metadata.validTextTranslation);
     assert.equal(Object.keys(b.idServersDetails()).length, 1);
@@ -361,12 +317,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements idServersEntries()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.equal(Object.keys(b.idServersEntries()).length, 0);
     b.importFromObject(this.metadata.validTextTranslation);
     assert.equal(Object.keys(b.idServersEntries()).length, 1);
@@ -374,24 +326,16 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements entries()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entries('https://thedigitalbiblelibrary.org'));
     b.importFromObject(this.metadata.validTextTranslation);
     assert.equal(b.entries('https://thedigitalbiblelibrary.org').length, 1);
   });
 
   it('Implements entriesRevisions()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entriesRevisions('https://thedigitalbiblelibrary.org'));
     b.importFromObject(this.metadata.validTextTranslation);
     const entryKeys = Object.keys(b.entriesRevisions('https://thedigitalbiblelibrary.org'));
@@ -400,24 +344,16 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements entryRevisions()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entryRevisions('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce'));
     b.importFromObject(this.metadata.validTextTranslation);
     assert.equal(b.entryRevisions('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce').length, 1);
   });
 
   it('Implements entryRevisionsVariants()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entryRevisionsVariants('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce'));
     b.importFromObject(this.metadata.validTextTranslation);
     const revisionKeys = Object.keys(
@@ -431,12 +367,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements entriesLatestRevision()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entriesLatestRevision('https://thedigitalbiblelibrary.org'));
     b.importFromObject(this.metadata.validTextTranslation);
     const entryRecord = b.entriesLatestRevision('https://thedigitalbiblelibrary.org')['2880c78491b2f8ce'];
@@ -452,12 +384,8 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements entryRevisionVariants()', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({ storeClass: 'FSBurritoStore' },
+      this.storagePath);
     assert.isNull(b.entryRevisionVariants('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91'));
     b.importFromObject(this.metadata.validTextTranslation);
     b.importFromObject(this.metadata.validTextTranslation);
@@ -465,26 +393,22 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements exportToObject', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
     const md = b.exportToObject('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source');
     assert.isObject(md);
   });
 
   it('exportToObject raises exception if variant not found', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     try {
       b.importFromObject(this.metadata.validTextTranslation);
       const md = b.exportToObject('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '99', 'source');
@@ -495,13 +419,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements exportToDir', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -511,14 +433,39 @@ describe('FS Burrito Class', () => {
     assert.isTrue(fse.existsSync(path.join(this.bundleWritePath, 'release', 'audio', 'GEN', 'GEN_001.mp3')));
   });
 
-  it('Manipulates an ingredient in the ingredient buffer', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
+  it('Implements exportToZipfile', function () {
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
+    b.importFromObject(this.metadata.validAudioTranslation);
+    if (!fse.existsSync(this.bundleWritePath)) {
+      fse.mkdirSync(this.bundleWritePath, { recursive: false });
+    }
+    const toPath = path.join(this.bundleWritePath, '6e0d81a24efbb679.zip');
+    const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
+    const ingredientStats = b.bufferIngredientStats(ingredientUuid);
+    b.cacheIngredient('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source', ingredientStats);
+    b.exportToZipfile(
+      'https://thedigitalbiblelibrary.org',
+      '6e0d81a24efbb679',
+      '9',
+      'source',
+      toPath,
     );
+    assert.isTrue(fse.existsSync(toPath));
+    const zip = new AdmZip(toPath);
+    const zipContents = zip.getEntries().map((each) => each.name);
+    assert.include(zipContents, 'metadata.json', 'zip includes metadata');
+  });
+
+  it('Manipulates an ingredient in the ingredient buffer', function () {
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/GEN.usx', this.usxPath);
     const ingredients = b.bufferIngredients();
     assert.equal(ingredients.length, 1);
@@ -544,13 +491,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements cacheIngredient', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     assert.equal(ingredientCounts(b, 'https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source').join('/'), '6/0');
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
@@ -561,41 +506,37 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements addOrUpdateIngredient', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
-    var ingredientUrl = 'release/audio/GEN/GEN_001.mp3';
-    var ingredientUuid = b.bufferIngredientFromFilePath(ingredientUrl, this.mp3Path);
-    var ingredientStats = b.bufferIngredientStats(ingredientUuid);
+    const ingredientUrl = 'release/audio/GEN/GEN_001.mp3';
+    let ingredientUuid = b.bufferIngredientFromFilePath(ingredientUrl, this.mp3Path);
+    let ingredientStats = b.bufferIngredientStats(ingredientUuid);
     b.addOrUpdateIngredient('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source', ingredientStats);
     assert.equal(b.bufferIngredients().length, 0);
     assert.equal(ingredientCounts(b, 'https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source').join('/'), '179/1');
-    var md = b.metadataContent('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source');
-    assert.equal(md.ingredients[ingredientUrl]["mimeType"], "application/octet-stream");
+    let md = b.metadataContent('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source');
+    assert.equal(md.ingredients[ingredientUrl].mimeType, 'application/octet-stream');
     ingredientUuid = b.bufferIngredientFromFilePath(ingredientUrl, this.mp3Path);
     ingredientStats = b.bufferIngredientStats(ingredientUuid);
-    ingredientStats["mimeType"] = "audio/mpeg";
-    ingredientStats["scope"] = {"GEN": ["1"]};
+    ingredientStats.mimeType = 'audio/mpeg';
+    ingredientStats.scope = { GEN: ['1'] };
     b.addOrUpdateIngredient('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source', ingredientStats);
     assert.equal(ingredientCounts(b, 'https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source').join('/'), '179/1');
     md = b.metadataContent('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91', 'source');
-    assert.equal(md.ingredients[ingredientUrl]["mimeType"], "audio/mpeg");
-    assert.equal(md.ingredients[ingredientUrl]["scope"]["GEN"][0], "1");
+    assert.equal(md.ingredients[ingredientUrl].mimeType, 'audio/mpeg');
+    assert.equal(md.ingredients[ingredientUrl].scope.GEN[0], '1');
   });
 
   it('Implements deleteIngredient', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -606,13 +547,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements ingredients (list)', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -621,13 +560,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements ingredientContent', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -637,13 +574,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements ingredientLocation', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -652,13 +587,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements deleteEntryRevisionVariant', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -669,13 +602,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements deleteEntryRevision', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -686,13 +617,11 @@ describe('FS Burrito Class', () => {
   });
 
   it('Implements deleteEntry', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
@@ -705,72 +634,64 @@ describe('FS Burrito Class', () => {
   // Tests for persistant stores only (currently fs_burrito_store)
 
   it('Implements Garbage Collection for One Entry', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
     b.cacheIngredient('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source', ingredientStats);
-    this.jhn3Mp3Paths.forEach(function (jhn3path) {
-      var ingredientUuid = b.bufferIngredientFromFilePath('release/audio/JHN/JHN_003.mp3', jhn3path);
-      var ingredientStats = b.bufferIngredientStats(ingredientUuid);
+    this.jhn3Mp3Paths.forEach((jhn3path) => {
+      const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/JHN/JHN_003.mp3', jhn3path);
+      const ingredientStats = b.bufferIngredientStats(ingredientUuid);
       b.addOrUpdateIngredient('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source', ingredientStats);
     });
-    var jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')["release/audio/JHN/JHN_003.mp3"];
+    let jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')['release/audio/JHN/JHN_003.mp3'];
     assert.equal(Object.keys(jhn3Report).length, 2);
     b.gc('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679');
-    jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')["release/audio/JHN/JHN_003.mp3"];
+    jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')['release/audio/JHN/JHN_003.mp3'];
     assert.equal(Object.keys(jhn3Report).length, 1);
   });
-  
-  
+
+
   it('Implements Garbage Collection for Whole Store', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validAudioTranslation);
     const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/GEN/GEN_001.mp3', this.mp3Path);
     const ingredientStats = b.bufferIngredientStats(ingredientUuid);
     b.cacheIngredient('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source', ingredientStats);
-    this.jhn3Mp3Paths.forEach(function (jhn3path) {
-      var ingredientUuid = b.bufferIngredientFromFilePath('release/audio/JHN/JHN_003.mp3', jhn3path);
-      var ingredientStats = b.bufferIngredientStats(ingredientUuid);
+    this.jhn3Mp3Paths.forEach((jhn3path) => {
+      const ingredientUuid = b.bufferIngredientFromFilePath('release/audio/JHN/JHN_003.mp3', jhn3path);
+      const ingredientStats = b.bufferIngredientStats(ingredientUuid);
       b.addOrUpdateIngredient('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679', '9', 'source', ingredientStats);
     });
-    var jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')["release/audio/JHN/JHN_003.mp3"];
+    let jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')['release/audio/JHN/JHN_003.mp3'];
     assert.equal(Object.keys(jhn3Report).length, 2);
     b.gcAll();
-    jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')["release/audio/JHN/JHN_003.mp3"];
+    jhn3Report = b.gcMark('https://thedigitalbiblelibrary.org', '6e0d81a24efbb679')['release/audio/JHN/JHN_003.mp3'];
     assert.equal(Object.keys(jhn3Report).length, 1);
   });
-  
-  
+
+
   // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('Persistant metadata storage', function () {
-    const b = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     b.importFromObject(this.metadata.validTextTranslation);
-    const b2 = new FSBurritoStore(
-      {
-        storeClass: 'FSBurritoStore',
-        validation: 'burrito',
-      },
-      this.storagePath,
-    );
+    const b2 = new FSBurritoStore({
+      storeClass: 'FSBurritoStore',
+      validation: 'burrito',
+    },
+    this.storagePath);
     assert.equal(b2.entryRevisionVariants('https://thedigitalbiblelibrary.org', '2880c78491b2f8ce', '91').length, 1);
   });
 });


### PR DESCRIPTION
Provides basic support for dumping a variant into a zip file. 
Some possibilities for improvement:
- how do we deal with missing ingredients?
- how do we deal with large zips (i.e. do we attempt to zip video)?
- how do we zip without holding the whole thing in memory in the interim?